### PR TITLE
Provision applications in --repair mode to support existing sources

### DIFF
--- a/.cakebox/Vagrantfile.rb
+++ b/.cakebox/Vagrantfile.rb
@@ -231,7 +231,10 @@ class Cakebox
       end
     end
 
-    # Install fully working framework applications for all yaml specified "apps"
+    # Install fully working framework applications for all yaml specified "apps".
+    # The --repair parameter is appended so only missing components will be
+    # installed when the sources already exist (e.g. when recreating a new box
+    # with existing sources in a mapped Synced Folder)
     unless settings["apps"].nil?
       settings["apps"].each do |app|
         config.vm.provision "shell" do |s|
@@ -239,6 +242,7 @@ class Cakebox
           s.inline = "bash /cakebox/console/bin/cake application add $@"
           s.args = [ app["url"] ]
           s.args.push(app["options"]) if !app["options"].nil?
+          s.args.push('--repair')
         end
       end
     end


### PR DESCRIPTION
Required for:

+ solving https://github.com/alt3/cakebox-console/issues/65
+ using --repair option implemented in https://github.com/alt3/cakebox-console/issues/65

## Important

Make sure to update your local cakebox repo if you have configured applications in your yaml