### PR TITLE
Allow users to specify a path to their custom  box-customization script

### DIFF
--- a/.cakebox/Vagrantfile.rb
+++ b/.cakebox/Vagrantfile.rb
@@ -264,16 +264,16 @@ class Cakebox
 
     # Upload and run user created customization bash script (if found) to allow
     # the user to create fully re-provisionable box customizations.
-    unless settings['customization_script'].nil?
-      if ( settings['customization_script'] =~ /^~/ )
-        settings['customization_script'] = settings['customization_script'].sub(/^~/, Dir.home)
+    unless settings['user_script'].nil?
+      if ( settings['user_script'] =~ /^~/ )
+        settings['user_script'] = settings['user_script'].sub(/^~/, Dir.home)
       end
 
-      if File.exists?(settings['customization_script'])
-        config.vm.provision "file", source: settings['customization_script'], destination: "/home/vagrant/.cakebox/last-known-customization-script.sh"
+      if File.exists?(settings['user_script'])
+        config.vm.provision "file", source: settings['user_script'], destination: "/home/vagrant/.cakebox/last-known-user-script.sh"
         config.vm.provision "shell" do |s|
           s.privileged = false
-          s.inline = "bash /home/vagrant/.cakebox/last-known-customization-script.sh"
+          s.inline = "bash /home/vagrant/.cakebox/last-known-user-script.sh"
         end
       end
     end

--- a/Cakebox.yaml.default
+++ b/Cakebox.yaml.default
@@ -35,3 +35,5 @@ sites:
 databases:
 
 software:
+
+customization_script:

--- a/Cakebox.yaml.default
+++ b/Cakebox.yaml.default
@@ -36,4 +36,4 @@ databases:
 
 software:
 
-customization_script:
+user_script:


### PR DESCRIPTION
Adds ``customization_script`` key to the yaml, takes a full path (including name of the bash script).

Working example:


```yaml
customization_script: ~/scripts/my-cakebox-tuner.sh
```