### PR TITLE
Refactors yaml handling for apt_packages and user scripts

### DIFF
--- a/Cakebox.yaml.default
+++ b/Cakebox.yaml.default
@@ -34,6 +34,7 @@ vhosts:
 
 databases:
 
-apt_packages:
+extra:
+  - apt_packages:
 
-user_script:
+  - scripts:


### PR DESCRIPTION
Adds an ``extra`` section to the yaml for specifying unlimited

+ apt packages
+ user created bash scripts

```yaml
extra:
  - apt_packages:
      - whois
      - dos2unix
  - scripts:
      - ~/scripts/my-cakebox-tuner.sh
      - /path/to/another/user/customization/script.sh
```

Should satisfy even the most demanding user :tada: :birthday: :balloon: :tada: 