### PR TITLE
fix wrong url in Cakebox.yaml.default's comment

### DIFF
--- a/Cakebox.yaml.default
+++ b/Cakebox.yaml.default
@@ -3,7 +3,7 @@
 #
 #  Spaced indentation MUST be used or your box will not start!
 #
-#  https://cakebox.readthedocs.org/en/latest/configuration/cakebox-yml
+#  https://cakebox.readthedocs.org/en/latest/usage/cakebox-yaml/
 # ------------------------------------------------------------------------
 vm:
   hostname: cakebox


### PR DESCRIPTION
I fixed wrong url in Cakebox.yaml.default's comment.
If you are OK, merge this pull request.