### PR TITLE
Adds yaml option for private or public network

### DIFF
--- a/.cakebox/Vagrantfile.rb
+++ b/.cakebox/Vagrantfile.rb
@@ -14,6 +14,7 @@ class Cakebox
     settings["vm"] =  Hash.new
     settings["vm"]["hostname"] = "cakebox"
     settings["vm"]["ip"] = "10.33.10.10"
+    settings["vm"]["network"] = "private"
     settings["vm"]["memory"] = 1024
     settings["vm"]["cpus"] = 1
     settings["cakebox"] =  Hash.new
@@ -47,8 +48,12 @@ class Cakebox
     config.vm.box_url = "https://alt3-aee.kxcdn.com/cakebox.box"
     config.vm.hostname = settings["vm"]["hostname"]
 
-    # Configure a private network IP (since DHCP is known to cause SSH timeouts)
-    config.vm.network :private_network, ip: settings["vm"]["ip"]
+    # Configure a private or public network IP
+    if settings['vm']['network'] == 'public'
+      config.vm.network :public_network, ip: settings["vm"]["ip"]
+    else
+      config.vm.network :private_network, ip: settings["vm"]["ip"]
+    end
 
     # Optimize box settings
     config.vm.provider "virtualbox" do |vb|

--- a/Cakebox.yaml.default
+++ b/Cakebox.yaml.default
@@ -8,6 +8,7 @@
 vm:
   hostname: cakebox
   ip: 10.33.10.10
+  network: private
   memory: 1024
   cpus: 1
 

--- a/docs/sources/usage/cakebox-yaml.md
+++ b/docs/sources/usage/cakebox-yaml.md
@@ -31,6 +31,7 @@ Cakebox.yaml with a lot of different provisioning variations.
 vm:
   hostname: cakebox
   ip: 10.33.10.10
+  network: private
   memory: 2048
   cpus: 1
 
@@ -126,6 +127,7 @@ Option    | Description
 :---------|:------------
 hostname  | hostname used by your box
 ip        | ip-address used to connect to your box
+network   | "private" for localhost access only (default) or "public"
 memory    | amount of memory available to your box (in MB)
 cpus      | number of virtual CPUs available to your box
 
@@ -133,6 +135,7 @@ cpus      | number of virtual CPUs available to your box
 vm:
   hostname: cakebox
   ip: 10.33.10.10
+  network: private
   memory: 2048
   cpus: 1
 ```


### PR DESCRIPTION
This PR introduces a new yaml configuration option called `network` which allows you to choose between the vagrant `private` and `public` network interfaces.

*Please note that the yaml will fall back to `private` if any other value is used.*

### Why

Using a public vagrant network allows you to expose your box over your (local) network which is extremely useful for situations where testing from your workstation alone just won't cut it (e.g. when developing mobile applications).  

A real world use case would be testing your mobile application from a non-broken iPhone.:

1. Configure your yaml to use the `public` vagrant network
2. Create a public DNS record `cakebox.yourdomain.com` pointing to the ip-address of your box (e.g. `192.168.1.10`)
3. Open your iPhone and browse to `cakebox.yourdomain.com`

