### PR TITLE
Adds automatic (daily) backups

### DIFF
--- a/.cakebox/.multibackup.conf
+++ b/.cakebox/.multibackup.conf
@@ -1,0 +1,37 @@
+## ============================================
+## Default cakebox multibackup configuration.
+##
+## Uploaded to /home/vagrant.
+##
+## https://github.com/frdmn/tar-multibackup
+## ============================================
+
+# Timestamp format, used in the backup target filename
+timestamp=$(date +%Y%m%d)
+
+# Destination where you want to store your backups
+backup_destination="/cakebox/backups"
+
+# Folders to backup
+folders_to_backup=(
+  "/etc/nginx"
+  "/home/vagrant/.cakebox"
+)
+
+# Files and folders that are excluded in the tar command
+tar_excludes=()
+
+# How long to you want to keep your backups (in days)
+backup_retention="+90"
+
+# Commands that are executed before the backup started
+pre_commands=(
+  'mkdir /cakebox/backups/_app-configs -p'
+  'mkdir /cakebox/backups/_mysql -p'
+)
+
+# Commands that are executed after the backup is completed
+post_commands=(
+  'xtrabackup --backup --target-dir=/cakebox/backups/_mysql/$(date "+%Y%m%d")'
+  'find /home/vagrant \( -name \app.php -o -name \.env \) | xargs tar czf /cakebox/backups/_app-configs/$(date "+%Y%m%d").tar.gz'
+)

--- a/.cakebox/Vagrantfile.rb
+++ b/.cakebox/Vagrantfile.rb
@@ -263,6 +263,12 @@ class Cakebox
       end
     end
 
+    # Install and configure automated backups
+    config.vm.provision "shell" do |s|
+      s.privileged = true
+      s.inline = "bash /cakebox/bash/backup-installer.sh"
+    end
+
     # Install extras
     unless settings["extra"].nil?
       settings["extra"].each do | hash |

--- a/.cakebox/backups/README.md
+++ b/.cakebox/backups/README.md
@@ -1,5 +1,3 @@
 # Backups
 
-This directory will be used for backups of your:
-
-+ MySQL database server (full)
+This local directory will hold daily backups of important box-files.

--- a/.cakebox/bash/backup-installer.sh
+++ b/.cakebox/bash/backup-installer.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+EXECUTABLE="/usr/local/bin/multibackup"
+CONFIG_LOCAL="/cakebox/.multibackup.conf"
+CONFIG_BOX="/home/vagrant/.multibackup.conf"
+CRON_FILE="/etc/cron.d/backup-liveconfig"
+
+printf %63s |tr " " "-"
+printf '\n'
+printf "Checking automated backups\n"
+printf %63s |tr " " "-"
+printf '\n'
+
+# Do nothing if the multibackup executable already exists
+if [ -f "$EXECUTABLE" ]; then
+	echo "* Skipping: multibackup executable already exists"
+	exit 0
+fi
+
+# Install tar-multibackup as described at https://github.com/frdmn/tar-multibackup
+echo "* Installing multibackup"
+cd /usr/local/src
+git clone https://github.com/frdmn/tar-multibackup.git
+ln -sf /usr/local/src/tar-multibackup/multibackup /usr/local/bin/multibackup
+
+# Upload cakebox-specific config file that will backup:
+# - nginx sites
+# - nginx conf files
+# - last known uploaded files
+# - all databases (percona/mysql hot backup)
+echo "* Placing default configuration file"
+OUTPUT=$(cp "$CONFIG_LOCAL" "$CONFIG_BOX")
+EXITCODE=$?
+if [ "$EXITCODE" -ne 0 ]; then
+	echo $OUTPUT
+	echo "FATAL: non-zero cp exit code ($EXITCODE)"
+	exit 1
+fi
+
+# Set file permissions on config file to vagrant user
+echo "* Setting configuration file permissions"
+OUTPUT=$(sudo chown vagrant:vagrant "$CONFIG_BOX" -R 2>&1)
+EXITCODE=$?
+if [ "$EXITCODE" -ne 0 ]; then
+	echo $OUTPUT
+	echo "FATAL: non-zero chown exit code ($EXITCODE)"
+	exit 1
+fi
+
+# Create daily cron (runs at 5:00 AM)
+echo "* Creating daily cron job"
+echo '0 5 * * *        root        CONFIG=/home/vagrant/.multibackup.conf /usr/local/bin/multibackup &>/dev/null' > "$CRON_FILE"
+
+# Provisioning feedback
+echo "Installation completed successfully!"

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 !mkdocs.yml
 !README.md
 !Vagrantfile
+!.travis.yml
+!Gemfile
+!.rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+Metrics/LineLength:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: false
+
+language: ruby
+
+rvm:
+  - 2.2
+  
+matrix:
+  fast_finish: true
+
+script:
+  - bundle exec rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org/'
+
+gem 'rubocop'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](.cakebox/LICENSE.txt)
+[![Build Status](https://travis-ci.org/alt3/cakebox.svg?style=flat-square)](https://travis-ci.org/alt3/cakebox)
 [![Documentation Status](https://readthedocs.org/projects/cakebox/badge?style=flat-square)](https://cakebox.readthedocs.org)
 [![Total Downloads](https://img.shields.io/packagist/dt/alt3/cakebox-console.svg?style=flat-square)](https://packagist.org/packages/alt3/cakebox-console)
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](.cakebox/LICENSE.txt)
 
 # Cakebox
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,13 +1,21 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-VAGRANTFILE_API_VERSION = '2'
+VAGRANTFILE_API_VERSION = '2'.freeze
 
-rootFolder = "#{File.dirname(__FILE__)}"
-require rootFolder + File::SEPARATOR + '.cakebox' + File::SEPARATOR + 'Vagrantfile.rb'
+root_folder = File.dirname(__FILE__).to_s
+
+vagrant_file = root_folder + File::SEPARATOR + '.cakebox' + File::SEPARATOR + 'Vagrantfile.rb'
+require vagrant_file
+
 require 'yaml'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  raise Vagrant::Errors::VagrantError.new, 'Fatal: your Cakebox.yaml is missing' unless File.exist?(rootFolder + File::SEPARATOR + 'Cakebox.yaml')
-  Cakebox.configure(config, YAML::load(File.read(rootFolder + File::SEPARATOR + 'Cakebox.yaml')))
+  user_yaml = root_folder + File::SEPARATOR + 'Cakebox.yaml'
+
+  unless File.exist?(user_yaml)
+    raise Vagrant::Errors::VagrantError.new, 'Fatal: your Cakebox.yaml is missing'
+  end
+
+  Cakebox.configure(config, YAML.safe_load(File.read(user_yaml)))
 end

--- a/docs/sources/usage/backups.md
+++ b/docs/sources/usage/backups.md
@@ -1,3 +1,25 @@
 # Introduction
 
-Placeholder for ``cakebox backup database``
+Cakebox uses [multibackup](https://github.com/frdmn/tar-multibackup) to create daily
+backups of critical box files which are then stored on your local machine for
+safe keeping.
+
+## Good to know
+
+- backups can be found on your local machine in the `/.cakebox/backups` folder
+- backup retention: 90 days
+- to manually start the backup run `sudo multibackup` inside your box
+- backups are created daily at 5:00 AM. To change:
+  - edit `/etc/cron.d/backup-liveconfig` (visit [crontab guru](https://crontab.guru) for help)
+  - reload cron by running `sudo service cron reload`
+
+## Configuration
+
+The default configuration file `/home/vagrant/.multibackup.conf` will backup:
+
+- all `app.php` and `.env` configuration files found in /home/vagrant (recursively)
+- the full database server with all databases (using [Percona Xtrabackup](https://www.percona.com/software/mysql-database/percona-xtrabackup))
+- `/etc/nginx`
+- `/home/vagrant/.cakebox`
+
+Additional folders can be added to the backups by specifying them in the configuration file.


### PR DESCRIPTION
This PR adds a provisioning script that installs [multibackup](https://github.com/frdmn/tar-multibackup) and configures it to automatically create daily backups of useful files (stored on your local machine for safe keeping).

### Enabling

To enable the automatic backups:

1. `cd` to the cakebox folder on your local machine
2. `git pull`
3. `vagrant reload --provision`

If things went well you should see vagrant provisioning feedback similar to:

```bash
==> default: ---------------------------------------------------------------
==> default: Checking automated backups
==> default: ---------------------------------------------------------------
==> default: * Installing multibackup
==> default: Cloning into 'tar-multibackup'...
==> default: * Placing default configuration file
==> default: * Setting configuration file permissions
==> default: * Creating daily cron job
==> default: Installation completed successfully!
```

### Configuration

Only folders specified in `~/.multibackup.conf` will be included in the backups. The default configuration file will backup:

- all `app.php` and `.env` configuration files found in /home/vagrant (recursively)
- the full database server with all databases (using [Percona Xtrabackup](https://www.percona.com/software/mysql-database/percona-xtrabackup))
- `/etc/nginx`
- `/home/vagrant/.cakebox`

### Good to know:

- backups can be found on your local machine in the `/.cakebox/backups` folder
- backup retention: 90 days
- to manually start the backup run `sudo multibackup` inside your box
- backups are created daily at 5:00 AM. To change:
  - edit `/etc/cron.d/backup-liveconfig` (visit [crontab guru](https://crontab.guru) for help)
  - reload cron by running `sudo service cron reload`

Refs #16 and https://github.com/frdmn/tar-multibackup/issues/4.